### PR TITLE
Add support to ignore SSL certificate errors using a custom HTTP client with TLS configuration.

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"log"
@@ -90,6 +91,13 @@ func constructEndpointPayloads(domain, path string) []string {
 	}
 }
 
+// create a custom Http client with insecure transport
+var insecureHTTPClient = &http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	},
+}
+
 func penetrateEndpoint(wg *sync.WaitGroup, url string, header ...string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -106,7 +114,8 @@ func penetrateEndpoint(wg *sync.WaitGroup, url string, header ...string) {
 		req.Header.Set(h, headerValue)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	//resp, err := http.DefaultClient.Do(req)
+	resp, err := insecureHTTPClient.Do(req) // use the custom client to send the request
 	if err != nil {
 		log.Fatal(Red(err))
 	}


### PR DESCRIPTION
- Added a custom HTTP client with InsecureSkipVerify enabled.
- Updated the penetrateEndpoint function to use the new client.
- Enhanced error handling and logging for SSL-related issues.